### PR TITLE
fix fatal error in start method

### DIFF
--- a/Development/Source/Swifter/MockNetworkServer.swift
+++ b/Development/Source/Swifter/MockNetworkServer.swift
@@ -81,13 +81,19 @@ extension MockNetworkServer: MockNetworkServerProtocol {
         }
 
         server = HttpServer()
-        start(server: server, on: port)
+        do {
+            try server?.start(port)
+        } catch {
+            server = nil
+            return nil
+        }
 
         server?.notFoundHandler = { _ in
             .notFound
         }
 
         guard let port = try? server?.port() else {
+            server = nil
             return nil
         }
 
@@ -104,16 +110,6 @@ extension MockNetworkServer: MockNetworkServerProtocol {
         server?.stop()
         removeAllStubs()
         server = nil
-    }
-
-    // MARK: Private
-
-    private func start(server: HttpServer?, on port: in_port_t) {
-        do {
-            try server?.start(port)
-        } catch {
-            fatalError("Couldn't start the mock network server. \n\(String(describing: error))")
-        }
     }
 }
 


### PR DESCRIPTION
Столкнулись с проблемой:
Нам нужно в проекте запускать тесты приоритетно на определенном порту, но если не получается - просто меняем порт и пробуем запустить.
В текущей реализации, если не удалось запустить сервер - получаем fatalError, а не nil, что полностью останавливает процесс выполнения теста.

Поправил этот момент, теперь, если мы пытаемся запустить сервер, но не получается, просто возвращается nil, без fatalError